### PR TITLE
Quickfix avatar upload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -284,5 +284,5 @@ twine = "*"
 towncrier = ">=18.6.0rc1"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core==1.2.0", "setuptools_rust==1.5.2"]
 build-backend = "poetry.core.masonry.api"

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -66,8 +66,8 @@ class ProfileHandler:
         self.user_directory_handler = hs.get_user_directory_handler()
         self.request_ratelimiter = hs.get_request_ratelimiter()
 
-        self.max_avatar_size = hs.config.server.max_avatar_size
-        self.allowed_avatar_mimetypes = hs.config.server.allowed_avatar_mimetypes
+        self.max_avatar_size = None
+        self.allowed_avatar_mimetypes = None
 
         self.server_name = hs.config.server.server_name
 


### PR DESCRIPTION
Context :  From https://github.com/tchapgouv/tchap-infra/issues/1445
We are unable to upload avatar image with the media_repo s3 enable.

To reproduce : 
* (on a mainlined HS)
* go to settings > general
* choose a picture as avatar
* Click save

I got a 403 Forbidden : 
``` 
# event_creator logs
Nov 24 15:44:36 tchap-agent2 matrix-synapse_event_creator[32188]: 2022-11-24 15:44:36,122 - synapse.handlers.profile - 368 - WARNING - PUT-73- Forbidding avatar change to mxc://matrix.agent2.tchap.incubateur.net/25bdfab63055de70d8615140fdd213c5b3eaa581: avatar not on server

Nov 24 15:44:36 tchap-agent2 matrix-synapse_event_creator[32188]: 2022-11-24 15:44:36,123 - synapse.http.server - 104 - INFO - PUT-73- <XForwardedForRequest at 0x7f9d1c08a5f8 method='PUT' uri='/_matrix/client/r0/profile/%40guillaumevtest1-element.io%3Aagent2.tchap.incubateur.net/avatar_url' clientproto='HTTP/1.1' site='18000'> SynapseError: 403 - This avatar is not allowed

Nov 24 15:44:36 tchap-agent2 matrix-synapse_event_creator[32188]: 2022-11-24 15:44:36,124 - synapse.access.http.18000 - 448 - INFO - PUT-73- 82.66.178.196 - 18000 - {@guillaumevtest1-element.io:agent2.tchap.incubateur.net} Processed request: 0.015sec/0.001sec (0.003sec, 0.001sec) (0.003sec/0.006sec/4) 62B 403 "PUT /_matrix/client/r0/profile/%40guillaumevtest1-element.io%3Aagent2.tchap.incubateur.net/avatar_url HTTP/1.1" "Mozilla/5.0 (X11; Linux x86_64; rv:107.0) Gecko/20100101 Firefox/107.0" [0 dbevts]
```

This looks a lot like https://github.com/tchapgouv/tchap-infra/pull/1316 where Mat did [a quick fix on the old code](https://github.com/matrix-org/synapse-dinsic/commit/c7faf3163f1ec8fb3df2b7b00ca7b2a65ae81f6b) to resolve it.

On the mainlined code, fail happens [here](https://github.com/matrix-org/synapse/blob/develop/synapse/handlers/profile.py#L321)


Actual upload of the image works well : 
```
# media_repo s3
time="2022-11-24 14:44:35.911 Z" level=info msg="Replying with result: *r0.MediaUploadedResponse &{ContentUri:mxc://matrix.agent2.tchap.incubateur.net/25bdfab63055de70d8615140fdd213c5b3eaa581 Blurhash:}" contentLength=130262 contentType=image/jpeg host=matrix.agent2.tchap.incubateur.net method=POST queryString="filename=unnamed+-+205.jpg" remoteAddr=82.66.178.196 requestId=REQ-14255 resource=/_matrix/media/r0/upload usingForwardedHost=false
```